### PR TITLE
✨ Add CSS to give buffer for Sticky

### DIFF
--- a/public/css/utilities.css
+++ b/public/css/utilities.css
@@ -1,3 +1,6 @@
 /* html {
     scroll-behavior: smooth;
 } */
+.top-body {
+    top: 70px;
+}

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -7,7 +7,7 @@
 <div id="intro" class="container mb-5 mt-5">
     <div class="row">
         <div class="col-sm-12 col-md-6 sticky-top animation-wrapper">
-            <div class="sticky-top animation-wrapper pt-5 mb-3">
+            <div class="position-sticky top-body animation-wrapper pt-5 mb-3">
                 <div class='network-animation'>
                     <div class='item'>
                         <div class='line'></div>


### PR DESCRIPTION
Quick fix for #61 by converting the animation wrapper from `.sticky-top` to `.position-sticky` and adding a class to add `top: 70px` (slightly more than the height of the navigation bar). 