### PR TITLE
Auto/light/dark mode

### DIFF
--- a/public/css/buttons.css
+++ b/public/css/buttons.css
@@ -3,8 +3,6 @@
     text-decoration: none;
     background: none;
 
-
-
     --bs-blue: #0d6efd;
     --bs-indigo: #6610f2;
     --bs-purple: #6f42c1;

--- a/public/css/colors.css
+++ b/public/css/colors.css
@@ -55,3 +55,20 @@ a.btn:focus{
 p{
     color: var(--color-secondary);
 }
+
+.navbar-toggler-icon {
+    filter: invert(1);
+}
+[data-bs-theme="dark"] .navbar-toggler-icon {
+    filter: none;
+}
+@media (prefers-color-scheme: light) {
+    [data-bs-theme="auto"] .navbar-toggler-icon {
+        filter: invert(1);
+    }
+}
+@media (prefers-color-scheme: dark) {
+    [data-bs-theme="auto"] .navbar-toggler-icon {
+        filter: none;
+    }
+}

--- a/public/css/tables.css
+++ b/public/css/tables.css
@@ -3,5 +3,5 @@ tr{
 }
 
 tr:nth-child(even) {
-    background-color: rgb(36, 36, 36);
+    background-color: var(--bs-body-bg);
 }

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -1,10 +1,47 @@
-:root {
-    --color-primary: #91a1f4;
-    --color-headline: #fffffe;
+/* Light mode (default and explicit) */
+:root,
+[data-bs-theme="light"] {
+    --color-primary: #5864b1;
+    --color-headline: #000000;
     --color-secondary: #72757e;
-    --color-highlight: #7f5af0;
-    --color-link: #7f5af0;
-    --color-link-hover: #fffffe;
+    --color-highlight: #623cd3;
+    --color-link: #623cd3;
+    --color-link-hover: #000000;
     --color-button: #7f5af0;
-    --background-primary: #16161a;
+    --background-primary: #f1f1fe;
+}
+
+:root {
+    --dark-color-primary: #91a1f4;
+    --dark-color-headline: #fffffe;
+    --dark-color-secondary: #72757e;
+    --dark-color-highlight: #7f5af0;
+    --dark-color-link: #7f5af0;
+    --dark-color-link-hover: #fffffe;
+    --dark-color-button: #7f5af0;
+    --dark-background-primary: #16161a;
+}
+
+[data-bs-theme="dark"] {
+    --color-primary: var(--dark-color-primary);
+    --color-headline: var(--dark-color-headline);
+    --color-secondary: var(--dark-color-secondary);
+    --color-highlight: var(--dark-color-highlight);
+    --color-link: var(--dark-color-link);
+    --color-link-hover: var(--dark-color-link-hover);
+    --color-button: var(--dark-color-button);
+    --background-primary: var(--dark-background-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-bs-theme]) {
+        --color-primary: var(--dark-color-primary);
+        --color-headline: var(--dark-color-headline);
+        --color-secondary: var(--dark-color-secondary);
+        --color-highlight: var(--dark-color-highlight);
+        --color-link: var(--dark-color-link);
+        --color-link-hover: var(--dark-color-link-hover);
+        --color-button: var(--dark-color-button);
+        --background-primary: var(--dark-background-primary);
+    }
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2,10 +2,12 @@ import onReady from './modules/onReady.js';
 import smoothScroll from './modules/smoothScroll.js';
 import animate from './modules/animation.js';
 import switchLanguage from './modules/language-switcher.js';
+import switchTheme from './modules/theme-switcher.js';
 
 onReady(() => {
     smoothScroll();
     switchLanguage();
+    switchTheme();
 
     const scroller = scrollama();
 

--- a/public/js/modules/theme-switcher.js
+++ b/public/js/modules/theme-switcher.js
@@ -1,0 +1,39 @@
+import Cookies from './cookies.js';
+
+const switchTheme = () => {
+    const themeSwitcher = document.getElementById('theme-switcher');
+    const htmlElement = document.documentElement;
+    let currentTheme = Cookies.getCookie('theme') || 'auto';
+
+    applyTheme(currentTheme);
+    themeSwitcher.value = currentTheme;
+
+    themeSwitcher.addEventListener('change', (ev) => {
+        const selectedTheme = ev.target.value;
+        applyTheme(selectedTheme);
+        Cookies.setCookie('theme', selectedTheme, 365);
+    });
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    mediaQuery.addEventListener('change', () => {
+        if (themeSwitcher.value === 'auto') {
+            applyTheme('auto');
+        }
+    });
+
+    function applyTheme(theme) {
+        switch (theme) {
+            case 'light':
+                htmlElement.dataset.bsTheme = 'light';
+                break;
+            case 'dark':
+                htmlElement.dataset.bsTheme = 'dark';
+                break;
+            case 'auto':
+            default:
+                delete htmlElement.dataset.bsTheme;
+        }
+    }
+};
+
+export default switchTheme;

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="{{current_locale.lang_dir}}" lang="{{current_locale.code}}" class="h-100" data-bs-theme="dark">
+<html dir="{{current_locale.lang_dir}}" lang="{{current_locale.code}}" class="h-100">
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -43,7 +43,7 @@
         <header class="position-absolute">
             <nav class="navbar navbar-expand-md navbar-dark fixed-top">
                 <div class="container-fluid">
-                <button class="navbar-toggler collapsed bg-dark" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+                <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="navbar-collapse collapse" id="navbarCollapse" style="">
@@ -62,14 +62,19 @@
                         </li>
                     </ul>
                 </div>
-                    <form id="language-switcher-wrapper" class="d-flex">
+                    <form id="language-switcher-wrapper" class="d-flex gap-2">
+                        <select id="theme-switcher" class="form-select mt-2 w-auto">
+                            <option value="auto">🌓 Auto</option>
+                            <option value="light">☀️ Light</option>
+                            <option value="dark">🌙 Dark</option>
+                        </select>
                         <select id="language-switcher" class="form-select mt-2">
                             <option style="display:none"></option>
                             {{#each translations}}
                                 <option value="{{this.code}}">{{this.label}}</option>
                             {{/each}}
                         </select>
-                    </form>                
+                    </form>
 
                 </div>
             </nav>


### PR DESCRIPTION
This adds auto, light and dark mode to the site.

- Default to auto (light) mode, as I feel that light mode is more uh… friendly 😄
- Adds a theme switcher near the language switcher, which allows user to switch to specific light/dark mode. Preference is stored in cookies.
- This is quite a minimum viable/effort change as I don't want to change too many things for now.
  - Some parts are a bit hacky like the inverted icon for navbar toggler.
  - `bg-dark` classes are still around in the handlebars and untouched.
  - Some buttons are untouched, tho' they still look kinda okay in light mode.

Some screenshots:

<img width="1582" alt="Current site and new site, side by side" src="https://github.com/user-attachments/assets/623eb565-b328-403e-af27-54203b313c15" />

<img width="1582" alt="Current site and new site, side by side, scrolled down a little" src="https://github.com/user-attachments/assets/33ee2d42-a1dd-49e7-8817-759a907b77e8" />
