### PR TITLE
Fix auto dark mode

### DIFF
--- a/public/css/colors.css
+++ b/public/css/colors.css
@@ -62,13 +62,3 @@ p{
 [data-bs-theme="dark"] .navbar-toggler-icon {
     filter: none;
 }
-@media (prefers-color-scheme: light) {
-    [data-bs-theme="auto"] .navbar-toggler-icon {
-        filter: invert(1);
-    }
-}
-@media (prefers-color-scheme: dark) {
-    [data-bs-theme="auto"] .navbar-toggler-icon {
-        filter: none;
-    }
-}

--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -11,37 +11,13 @@
     --background-primary: #f1f1fe;
 }
 
-:root {
-    --dark-color-primary: #91a1f4;
-    --dark-color-headline: #fffffe;
-    --dark-color-secondary: #72757e;
-    --dark-color-highlight: #7f5af0;
-    --dark-color-link: #7f5af0;
-    --dark-color-link-hover: #fffffe;
-    --dark-color-button: #7f5af0;
-    --dark-background-primary: #16161a;
-}
-
 [data-bs-theme="dark"] {
-    --color-primary: var(--dark-color-primary);
-    --color-headline: var(--dark-color-headline);
-    --color-secondary: var(--dark-color-secondary);
-    --color-highlight: var(--dark-color-highlight);
-    --color-link: var(--dark-color-link);
-    --color-link-hover: var(--dark-color-link-hover);
-    --color-button: var(--dark-color-button);
-    --background-primary: var(--dark-background-primary);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root:not([data-bs-theme]) {
-        --color-primary: var(--dark-color-primary);
-        --color-headline: var(--dark-color-headline);
-        --color-secondary: var(--dark-color-secondary);
-        --color-highlight: var(--dark-color-highlight);
-        --color-link: var(--dark-color-link);
-        --color-link-hover: var(--dark-color-link-hover);
-        --color-button: var(--dark-color-button);
-        --background-primary: var(--dark-background-primary);
-    }
+    --color-primary: #91a1f4;
+    --color-headline: #fffffe;
+    --color-secondary: #72757e;
+    --color-highlight: #7f5af0;
+    --color-link: #7f5af0;
+    --color-link-hover: #fffffe;
+    --color-button: #7f5af0;
+    --background-primary: #16161a;
 }

--- a/public/js/modules/theme-switcher.js
+++ b/public/js/modules/theme-switcher.js
@@ -31,7 +31,8 @@ const switchTheme = () => {
                 break;
             case 'auto':
             default:
-                delete htmlElement.dataset.bsTheme;
+                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                htmlElement.dataset.bsTheme = prefersDark ? 'dark' : 'light';
         }
     }
 };


### PR DESCRIPTION
Removing media query and rely on data-bs-theme completely.

Simplify this for now as there are too many Bootstrap variables and they only rely on [data-bs-theme] instead of media query, so changing this to accomodate Bootstrap's logic.

Before and after (Auto, but follow system's dark mode, set via devtools):

<img width="1582" alt="Screenshot 2025-06-13 at 6 38 49 PM" src="https://github.com/user-attachments/assets/3541498d-115a-4c0f-af66-08a10c7adfa8" />

I've tested Auto (light), Auto (dark), light and dark modes too, should be okay… 🤞