### PR TITLE
Use min-height on home page sections instead of fixed height to fix a…

### DIFF
--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -183,7 +183,7 @@
         </div>
     </div>
 </div>
-<div class="d-flex align-items-center justify-content-center vh-100 position-relative overflow-hidden text-center">
+<div class="d-flex align-items-center justify-content-center min-vh-100 position-relative overflow-hidden text-center">
     <div>
         <div id="into-the-fediverse"
             class="mx-auto my-5">


### PR DESCRIPTION
…n overlap of text with a button when large font size is used.