### PR TITLE
Update Mobilizon join URL

### DIFF
--- a/views/join.handlebars
+++ b/views/join.handlebars
@@ -55,7 +55,7 @@
                         </a>
                     </span>
                     <span class="logo-small-wrapper d-block d-md-inline-block d-lg-inline-block">
-                        <a href="https://mobilizon.fr/">
+                        <a href="https://mobilizon.org/#join">
                             <img width="50" height="50" alt="Mobilizon logo" class="logo-small" src="/images/logos/fediverse/mobilizon.svg">
                             Mobilizon
                         </a>


### PR DESCRIPTION
The current URL points to Mobilizon's original (French) instance. The suggested new one points to the Join block on their English project page instead.